### PR TITLE
Cli

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,5 +19,6 @@ setup(
         "gpio"
     ],
     url='https://github.com/ZeroPhone/Zerophone-API-Python',
-    download_url='https://github.com/ZeroPhone/zerophone-api-py/archive/{}.tar.gz'.format(version)
+    download_url='https://github.com/ZeroPhone/zerophone-api-py/archive/{}.tar.gz'.format(version),
+    entry_points={"console_scripts": ["zerophone_hw = zerophone_hw:main"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,6 @@ setup(
     install_requires=[
         "gpio"
     ],
-    url = 'https://github.com/ZeroPhone/Zerophone-API-Python',
-    download_url = 'https://github.com/ZeroPhone/zerophone-api-py/archive/{}.tar.gz'.format(version)
+    url='https://github.com/ZeroPhone/Zerophone-API-Python',
+    download_url='https://github.com/ZeroPhone/zerophone-api-py/archive/{}.tar.gz'.format(version)
 )

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ try:
 except ImportError:
     from distutils.core import setup
 
-version = "0.3.0"
+version = "0.3.1"
 
 setup(
     name='zerophone_hw',

--- a/zerophone_hw.py
+++ b/zerophone_hw.py
@@ -31,7 +31,7 @@ def is_charging():
         gpio.setup(chg_sense_gpio, gpio.IN)
         return bool(gpio.input(chg_sense_gpio))
     else:
-        raise NotImplementedException("Version not supported!")
+        raise NotImplemented("Version not supported!")
 
 
 class USB_DCDC():
@@ -49,7 +49,7 @@ class USB_DCDC():
         if self.hw_v == "gamma":
             return 510
         else:
-            raise NotImplementedException("Hardware version not supported!")
+            raise NotImplemented("Hardware version not supported!")
 
     def set_state(self, state):
         if not self.gpio_exported:
@@ -61,7 +61,7 @@ class USB_DCDC():
         elif self.switch_types[self.hw_v] == "gpio":
             gpio.set(self.gpio_num, state)
         else:
-            raise NotImplementedException("DC-DC switch type not supported!")
+            raise NotImplemented("DC-DC switch type not supported!")
 
     def on(self):
         self.set_state(True)
@@ -85,7 +85,7 @@ class GSM_Modem():
     def set_gpio_nums(self):
         self.gpios = {name: copy(self.gpio_dict) for name in self.gpio_names}
         if self.hw_v not in self.gpio_nums:
-            raise NotImplementedException("Hardware version not supported!")
+            raise NotImplemented("Hardware version not supported!")
         gpio_nums = self.gpio_nums[self.hw_v]
         for name, num in gpio_nums.items():
             self.gpios[name]["num"] = num
@@ -127,7 +127,7 @@ class RGB_LED():
         if version in self.led_types:
             return self.led_types[version]
         else:
-            raise NotImplementedException("Hardware version not supported!")
+            raise NotImplemented("Hardware version not supported!")
 
     def setup(self):
         if self.led_type in ["gpio", "gpio_inverted"]:
@@ -139,7 +139,7 @@ class RGB_LED():
         if self.hw_v == "gamma":
             return (498, 496, 497)
         else:
-            raise NotImplementedException("Hardware version not supported!")
+            raise NotImplemented("Hardware version not supported!")
 
     def set_color(self, color_str):
         try:
@@ -159,7 +159,7 @@ class RGB_LED():
                 if self.led_type == "gpio_inverted": gpio_state = not gpio_state
                 gpio.set(gpio_num, gpio_state)
         else:
-            raise NotImplementedException("LED control type not supported!")
+            raise NotImplemented("LED control type not supported!")
 
     def __getattr__(self, name):
         if name in self.color_mapping:

--- a/zerophone_hw.py
+++ b/zerophone_hw.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python2
+import argparse
 
 __all__ = ['get_hw_version_str', 'is_charging', 'RGB_LED', 'USB_DCDC', "GSM_Modem"]
 __version__ = '0.3.0'
@@ -34,12 +35,13 @@ def is_charging():
         raise NotImplemented("Version not supported!")
 
 
-class USB_DCDC():
+class USB_DCDC(object):
     gpio_exported = False
     gpio_state = None
 
     switch_types = {
-        "gamma": "gpio_inverted"}
+        "gamma": "gpio_inverted"
+    }
 
     def __init__(self):
         self.hw_v = get_hw_version_str()
@@ -73,13 +75,14 @@ class USB_DCDC():
         self.set_state(not self.gpio_state)
 
 
-class GSM_Modem():
+class GSM_Modem(object):
     gpio_dict = {"exported": False, "state": None, "num": None}
     gpio_names = ["ring", "reset", "dtr"]
     gpio_nums = {"gamma": {"ring": 501, "dtr": 500, "reset": 502}}
 
     def __init__(self):
         self.hw_v = get_hw_version_str()
+        self.gpios = {}
         self.set_gpio_nums()
 
     def set_gpio_nums(self):
@@ -107,7 +110,7 @@ class GSM_Modem():
     # TODO: add "get_ring_state" and "get_dtr_state" high-level functions
 
 
-class RGB_LED():
+class RGB_LED(object):
     color_mapping = {
         "white": (255, 255, 255),
         "red": (255, 0, 0),
@@ -137,7 +140,7 @@ class RGB_LED():
     def get_rgb_gpios(self):
         # returns GPIOs for red, green, blue
         if self.hw_v == "gamma":
-            return (498, 496, 497)
+            return 498, 496, 497
         else:
             raise NotImplemented("Hardware version not supported!")
 
@@ -145,7 +148,7 @@ class RGB_LED():
         try:
             self.set_rgb(*self.color_mapping[color_str])
         except KeyError:
-            raise ArgumentError("Color {} not found in color mapping!".format(color_str))
+            raise ValueError("Color {} not found in color mapping!".format(color_str))
 
     def set_rgb(self, *colors):
         if len(colors) != 3 or any([type(color) != int for color in colors]):
@@ -156,7 +159,8 @@ class RGB_LED():
             gpios = self.get_rgb_gpios()
             for i, gpio_num in enumerate(gpios):
                 gpio_state = colors[i] > 0  # Only 0 and 255 are respected
-                if self.led_type == "gpio_inverted": gpio_state = not gpio_state
+                if self.led_type == "gpio_inverted":
+                    gpio_state = not gpio_state
                 gpio.set(gpio_num, gpio_state)
         else:
             raise NotImplemented("LED control type not supported!")
@@ -167,8 +171,4 @@ class RGB_LED():
 
 
 if __name__ == "__main__":
-    led = RGB_LED()
-    dcdc = USB_DCDC()
-    while True:
-        print(is_charging())
-        sleep(1)
+    parser = argparse.ArgumentParser

--- a/zerophone_hw.py
+++ b/zerophone_hw.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python2
 import argparse
 
-__all__ = ['get_hw_version_str', 'is_charging', 'RGB_LED', 'USB_DCDC', "GSM_Modem"]
+__all__ = ['get_hw_version_str', 'is_charging', 'RGB_LED', 'USB_DCDC_Gamma', "GSM_Modem_Gamma"]
 __version__ = '0.3.0'
 
 import sys
@@ -26,44 +26,37 @@ def get_hw_version_str():
 
 
 def is_charging():
-    hw_v = get_hw_version_str()
-    if hw_v == "gamma":
-        chg_sense_gpio = 503
-        gpio.setup(chg_sense_gpio, gpio.IN)
-        return bool(gpio.input(chg_sense_gpio))
-    else:
-        raise NotImplemented("Version not supported!")
+    chg_sense_gpio = 503
+    gpio.setup(chg_sense_gpio, gpio.IN)
+    return bool(gpio.input(chg_sense_gpio))
 
 
 class USB_DCDC(object):
+    def __new__(cls, *args, **kwargs):
+        if get_hw_version_str() == "gamma":
+            return USB_DCDC_Gamma(*args, **kwargs)
+
+
+class USB_DCDC_Gamma(USB_DCDC):
     gpio_exported = False
     gpio_state = None
 
-    switch_types = {
-        "gamma": "gpio_inverted"
-    }
-
-    def __init__(self):
-        self.hw_v = get_hw_version_str()
+    def __init__(self, gpio_inverted=True):
+        self.gpio_inverted = gpio_inverted
         self.gpio_num = self.get_gpio_num()
 
     def get_gpio_num(self):
-        if self.hw_v == "gamma":
-            return 510
-        else:
-            raise NotImplemented("Hardware version not supported!")
+        return 510
 
     def set_state(self, state):
         if not self.gpio_exported:
             gpio.setup(self.gpio_num, gpio.OUT)
             self.gpio_exported = True
         self.gpio_state = state
-        if self.switch_types[self.hw_v] == "gpio_inverted":
+        if self.gpio_inverted:
             gpio.set(self.gpio_num, not state)
-        elif self.switch_types[self.hw_v] == "gpio":
-            gpio.set(self.gpio_num, state)
         else:
-            raise NotImplemented("DC-DC switch type not supported!")
+            gpio.set(self.gpio_num, state)
 
     def on(self):
         self.set_state(True)
@@ -76,6 +69,12 @@ class USB_DCDC(object):
 
 
 class GSM_Modem(object):
+    def __new__(cls, *args, **kwargs):
+        if get_hw_version_str() == "gamma":
+            return GSM_Modem_Gamma(*args, **kwargs)
+
+
+class GSM_Modem_Gamma(GSM_Modem):
     gpio_dict = {"exported": False, "state": None, "num": None}
     gpio_names = ["ring", "reset", "dtr"]
     gpio_nums = {"gamma": {"ring": 501, "dtr": 500, "reset": 502}}
@@ -111,6 +110,12 @@ class GSM_Modem(object):
 
 
 class RGB_LED(object):
+    def __new__(cls, *args, **kwargs):
+        if get_hw_version_str() == "gamma":
+            return RGB_LED_Gamma(*args, **kwargs)
+
+
+class RGB_LED_Gamma(RGB_LED):
     color_mapping = {
         "white": (255, 255, 255),
         "red": (255, 0, 0),
@@ -171,4 +176,4 @@ class RGB_LED(object):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser
+    pass

--- a/zerophone_hw.py
+++ b/zerophone_hw.py
@@ -203,15 +203,17 @@ def add_object_subparser(obj, name, sub_parsers):
     custom_subparser.set_defaults(__obj=obj)
 
 
-if __name__ == "__main__":
+def main():
     parser = argparse.ArgumentParser(prog='zerophone_hw', description='Zerophone Hardware Command Line Interface')
     subparsers = parser.add_subparsers()
-
     add_object_subparser(RGB_LED(), 'led', subparsers)
     add_object_subparser(USB_DCDC(), 'dcdc', subparsers)
     add_object_subparser(GSM_Modem(), 'modem', subparsers)
-
     args = parser.parse_args()
     if hasattr(args.__obj, '_setup'):
         getattr(args.__obj, '_setup')()
     getattr(args.__obj, args.command)(*args.params)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# purpose
add a CLI application to control zerophone's hardware from anywhere within the system

# implementation
## handling different hardware versions
As discussed on IRC, a factory patter is used. Some traces of the old method still exist. I didn't want to take the risk to break something

## arguments parsing
The method `add_object_subparser` is the key. For a given object it reads all the callable functions not starting with '`_`' and their docstring. It then constructs a subparser for it.

# bugs
`DCDC toggle` doesn't work because the DCDC object cannot reliably determine what state it's in in the first place.

# example usage
## getting help
```bash
root@zerophone ~# zerophone_hw --help
usage: zerophone_hw [-h] {led,dcdc,modem} ...

Zerophone Hardware Command Line Interface

positional arguments:
  {led,dcdc,modem}

```
## getting help for the led
```bash
root@zerophone ~# zerophone_hw led -h

usage: zerophone_hw led [-h] {off,set_color,set_rgb} [params [params ...]]

Controls the RGB led
	off	Turns the led off
	set_color	Sets the color of the led from a string
	set_rgb	Sets the color of the led from RGB values [0-255] range

positional arguments:
  {off,set_color,set_rgb}
  params
```
## playing with the led
```bash
root@zerophone ~# zerophone_hw led set_color red
root@zerophone ~# zerophone_hw led off
```